### PR TITLE
Updated tech progression

### DIFF
--- a/vision of the modpack/original vision doc.md
+++ b/vision of the modpack/original vision doc.md
@@ -331,7 +331,7 @@ End of tier: built first MV machine
 Main material: Steel
 Secondary material: Wrought Iron
 Cable materials: Tin, Copper
-Pipe materials: Bronze, Tin (Potin for high throughput usage)
+Pipe materials: Bronze, Tin, Potin
 
 </div>
 
@@ -350,7 +350,7 @@ Major challenges:
 Main material: Aluminium
 Secondary material: Wrought Iron
 Cable materials: Copper, Cupronickel
-Pipe material: Steel (Potin/Dark Steel for high throughput usage)
+Pipe material: Steel, Potin, Dark Steel
 </div>
 
 ## 2.v. HV Age
@@ -369,7 +369,7 @@ Major challenges:
 Main material: Stainless Steel
 Secondary material: Polyethylene
 Cable materials: Gold, Silver, Electrum
-Pipe material: Stainless Steel (Dark Steel for high throughput usage)
+Pipe material: Stainless Steel, Dark Steel
 
 Rocket tier 1, unlocked bodies:
 - Moon


### PR DESCRIPTION
As requested by Boubou, an update to the tech progression based on the current state of the game. This update does _not_ include the highest tiers (uev partially but not uiv+), those are better updated by other devs than me.

Bigger points:
- the suggestions to change EV to IV progression that were in the document were largely implemented. (tier 2 rocket change to require LuV circuits, coil change from tungstensteel to TPV requiring platinum, and the ore proc multis being EV now).

Only point were I think my opinion really entered (let me know what you think here specifically, though I think they are widely accepted points):
- I pointed out that luv/zpm are fairly empty and could see more content.
- I pointed out that Kevlar is not in a satisfying state currently (even though it is required for t9 now).