### PR TITLE
Create a guideline on how to review a PR and Dev inactivity

### DIFF
--- a/developer's code of conduct.md
+++ b/developer's code of conduct.md
@@ -27,8 +27,8 @@ When a PR is tagged as a balance affecting PR (currently "Affects Balance"), dev
 
 The question requirement may be bypassed in reasonable scenarios, such as emergency reverts.
 
-## Important
-Avoid reviewing a balancing PR if you're not intimately familiar with the potential implications of the proposed changes. This is especially true for balancing PRs, as they can have widespread effects on the entire community.
+## Reviewing a PR
+This will try to explain a few guidelines on how to review a PR. This it not to be followed 100%, but just a general guideline on how a review should go.
 
 ### Important
 You should avoid reviewing a balancing PR if you aren't very familiar with what will be the implications of the changes proposed in the PR. Especially if it's about balancing PRs, as this can affect the whole community in a bad way.


### PR DESCRIPTION
This PR aims to provide a small set of guidelines on how a dev can go about reviewing a PR. Written with the help of @GTNH-Colen @boubou19 and @mitchej123.

This PR also introduces a section about developper's inactivity, to explain why it's needed, what it does, and how one can be labeled as inactive.