### PR TITLE
Proposal for an expedited deprecation process.

### DIFF
--- a/developer's code of conduct.md
+++ b/developer's code of conduct.md
@@ -35,6 +35,11 @@ To improve review quality, in PR about new feature/feature change/balance change
       1) 
    5) Witchery
        1) Don't, if you want to add Witchery content, please add it to Forbidden Magic instead. Witchery  exists as a singular ARR island compared to the archipelagos that make up the other magic mods, no vast fields of addons like Thaumcraft, no open sourced code like Botania and Blood Magic, if you'd like to see new Witchery content, please help us recreate the vital portions in new, untethered, code.
+9) Expedition on deprecation
+   1) There are some allowances on the expedition of deprecation of certain pack content, i.e. not having to wait a full development cycle (typically half a year) under these specific circumstances.
+      1) At least 1/4th of the GregTech New Horizons development team agree to the deprecation. 
+      2) The content, in its current form (ignoring any past functionality) is currently unfunctional in any meaningful way.
+      3) Alternatively, if there already exists a replacement multi, that has already existed (with conversion recipes if need be) for at least a single stable release, instant termination is likewise applicable. 
 
 ## Balancing PRs
 They must follow the vision we have, and follow 4. of the Content Section. A PR affecting balancing should always be labeled as such, and not be mixed in with other unrelated changes in the same PR. For IV and below, follow 2. of the Content creation section. For LuV and above, it must at least have 2 approvals, and one of them must be a member of the github's admin team (list of them [here](https://github.com/orgs/GTNewHorizons/teams/admin)).


### PR DESCRIPTION
For a long time now, the formal deprecation process for GTNH has been "notify players that this is being deprecated, for one stable release, and terminate it the next dev cycle. This directly means that it usually takes up to a year to deprecate what is often fully unfunctional content such as Bart's original LEG from EMT.

Likewise, there has been a few moments where this process as a whole has been completely ignored in favour of an instant termination of service for a specific bit of content. One recent example of this was the PA debacle from earlier this cycle (that was later reversed).

There are many moments in which an expedited process of termination should be in effect, for example, the aforementioned EMT LEG which took nearly a year and a half after being replaced just to terminate.

As such, I would like to set in stone some guidelines to enact a formalized process for instant termination within certain cases, such as Bart's LEG or Hydropower's unfunctional and instance corrupting dam multi.